### PR TITLE
Provide better exceptions for errors when building the mapping plan

### DIFF
--- a/src/AutoMapper/QueryableExtensions/ProjectionBuilder.cs
+++ b/src/AutoMapper/QueryableExtensions/ProjectionBuilder.cs
@@ -110,10 +110,18 @@ public sealed class ProjectionBuilder : IProjectionBuilder
                     {
                         continue;
                     }
-                    var propertyProjection = TryProjectMember(propertyMap);
-                    if(propertyProjection != null)
+
+                    try
                     {
-                        propertiesProjections.Add(Bind(propertyMap.DestinationMember, propertyProjection));
+                        var propertyProjection = TryProjectMember(propertyMap);
+                        if(propertyProjection != null)
+                        {
+                            propertiesProjections.Add(Bind(propertyMap.DestinationMember, propertyProjection));
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        throw new AutoMapperMappingException("Error building queryable mapping strategy.", e, propertyMap);
                     }
                 }
             }
@@ -209,7 +217,17 @@ public sealed class ProjectionBuilder : IProjectionBuilder
             {
                 { CustomCtorExpression: LambdaExpression ctorExpression } => (NewExpression)ctorExpression.ReplaceParameters(instanceParameter),
                 { ConstructorMap: { CanResolve: true } constructorMap } =>
-                    New(constructorMap.Ctor, constructorMap.CtorParams.Select(map => TryProjectMember(map, map.DefaultValue(null)) ?? Default(map.DestinationType))),
+                    New(constructorMap.Ctor, constructorMap.CtorParams.Select(map =>
+                    {
+                        try
+                        {
+                            return TryProjectMember(map, map.DefaultValue(null)) ?? Default(map.DestinationType);
+                        }
+                        catch (Exception e)
+                        {
+                            throw new AutoMapperMappingException("Error building constructor projection strategy.", e, map);
+                        }
+                    })),
                 _ => New(typeMap.DestinationType)
             };
         }

--- a/src/AutoMapper/TypeMap.cs
+++ b/src/AutoMapper/TypeMap.cs
@@ -204,8 +204,15 @@ public sealed class TypeMap
             return;
         }
         _sealed = true;
-        _details?.Seal(configuration, this);
-        MapExpression = Projection ? EmptyLambda : CreateMapperLambda(configuration);
+        try
+        {
+            _details?.Seal(configuration, this);
+            MapExpression = Projection ? EmptyLambda : CreateMapperLambda(configuration);
+        }
+        catch (Exception e)
+        {
+            throw new AutoMapperMappingException("Error creating mapping strategy.", e, this);
+        }
         SourceTypeDetails = null;
         DestinationTypeDetails = null;
     }


### PR DESCRIPTION
This PR adds diagnostic exceptions around mapping individual members. If there's an exception building the expression trees there's not details given from those exceptions.

This covers:
- In memory mapping strategies
  - The type map as a whole
  - Property maps
  - Path maps
  - Constructor maps
- LINQ mapping
  - Property maps
  - Constructor maps
 
Fixes #4558, #4563