### PR TITLE
ci: publish fork-PR test reports via workflow_run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,13 @@ env:
     DOTNET_NOLOGO: true
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     MINVERBUILDMETADATA: build.${{ github.run_id }}.${{ github.run_attempt}}
+# This workflow runs untrusted code from fork PRs, so it keeps a read-only token
+# and never needs secrets. Test results are published by a separate workflow
+# (test-report.yml, triggered via workflow_run) that runs in the base-repo
+# context with checks:write. See issue #4642.
 permissions:
   id-token: write
   contents: read
-  checks: write
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -37,17 +40,14 @@ jobs:
     - name: Build and Test
       run: ./Build.ps1
       shell: pwsh
-    - name: Report Test Results
-      uses: dorny/test-reporter@v1
-      # Publishing the report needs checks:write, which GitHub forces to read-only
-      # for pull_request runs from forks. Don't let that fail the build; the test
-      # step itself already reflects pass/fail.
-      continue-on-error: true
+    - name: Upload Test Results
+      # Publishing happens in test-report.yml, which downloads this artifact.
+      uses: actions/upload-artifact@v4
       if: success() || failure()
       with:
-        name: Test Results (Linux)
+        name: test-results-Linux
         path: artifacts/**/*.trx
-        reporter: dotnet-trx
+        if-no-files-found: ignore
   build-windows:
     needs: build
     strategy:
@@ -79,16 +79,14 @@ jobs:
       - name: Build and Test
         run: ./Build.ps1
         shell: pwsh
-      - name: Report Test Results
-        uses: dorny/test-reporter@v1
-        # See note on the Linux job: report publishing is best-effort and must
-        # never fail the build (forked-PR tokens are read-only).
-        continue-on-error: true
+      - name: Upload Test Results
+        # Publishing happens in test-report.yml, which downloads this artifact.
+        uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
-          name: Test Results (Windows)
+          name: test-results-Windows
           path: artifacts/**/*.trx
-          reporter: dotnet-trx
+          if-no-files-found: ignore
       - name: Sign packages
         # Signing uses the Azure Key Vault login above; only runs on main.
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,14 @@ env:
     DOTNET_NOLOGO: true
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     MINVERBUILDMETADATA: build.${{ github.run_id }}.${{ github.run_attempt}}
-# This workflow runs untrusted code from fork PRs, so it keeps a read-only token
-# and never needs secrets. Test results are published by a separate workflow
-# (test-report.yml, triggered via workflow_run) that runs in the base-repo
-# context with checks:write. See issue #4642.
+# On pull requests — especially from forks, where GitHub forces the token to
+# read-only — this workflow needs no secrets and no write access: it only builds,
+# tests, and uploads .trx artifacts. Test results are published by a separate
+# workflow (test-report.yml, triggered via workflow_run) that runs in the
+# base-repo context with checks:write. The only steps that touch secrets/OIDC are
+# the main-only signing and publishing steps in build-windows, which is the sole
+# job granted id-token: write (scoped at the job level below). See issue #4642.
 permissions:
-  id-token: write
   contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -50,6 +52,12 @@ jobs:
         if-no-files-found: ignore
   build-windows:
     needs: build
+    # id-token:write is required only for the main-only Azure OIDC login used to
+    # code-sign packages. Granting it here (not at the workflow level) keeps it
+    # off the Linux build job and the default for any future jobs.
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       fail-fast: false
     runs-on: windows-latest

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,0 +1,36 @@
+name: Test Report
+
+# Publishes test results for runs of the CI workflow, including pull requests
+# from forks. The CI workflow itself runs with a read-only token (GitHub forces
+# this for fork PRs) and only uploads the .trx files as artifacts. This workflow
+# is triggered by workflow_run, so it runs in the *base repository* context with
+# a writable token and can call the Checks API to publish inline reports.
+# See issue #4642.
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types:
+      - completed
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish Test Results
+        uses: dorny/test-reporter@v1
+        with:
+          # Download every test-results-* artifact from the triggering CI run and
+          # publish one check per platform, e.g. "Test Results (Linux)".
+          artifact: /test-results-(.*)/
+          name: Test Results ($1)
+          path: '**/*.trx'
+          reporter: dotnet-trx
+          # A build that fails before producing any .trx shouldn't make this
+          # report red; the CI run already reflects that failure.
+          fail-on-empty: 'false'


### PR DESCRIPTION
Fixes the fork-PR CI failures tracked in #4642 — and does it the *right* way, so fork PRs get real inline test reports instead of silently swallowed ones.

## Problem

For `pull_request` runs from a **fork**, GitHub forcibly downgrades `GITHUB_TOKEN` to read-only (untrusted code must not get write access to the base repo) and withholds secrets. Two steps in `ci.yml` therefore failed on every fork PR even when all tests passed:

- **`dorny/test-reporter`** calls the Checks API to publish results, which needs `checks: write`. With a read-only token it gets `403 Resource not accessible by integration` and (default `fail-on-error: true`) fails the job.
- **`Azure Login via OIDC`** uses `secrets.AZURE_*`, which are empty on fork PRs, so login fails. This step only exists to sign/publish packages — a `main`-only path.

## Fix — split building from reporting (`workflow_run` pattern)

**`ci.yml`** (runs on the PR, read-only token, no secrets):
- Replaces the `Report Test Results` steps with `Upload Test Results` — the `.trx` files are uploaded as `test-results-Linux` / `test-results-Windows` artifacts.
- Gates `Azure Login via OIDC` and `Sign packages` to `refs/heads/main` (matching the existing `Push to MyGet` guard).
- Drops `checks: write` from `permissions` — the build no longer touches the Checks API.

**`test-report.yml`** (new, triggered by `workflow_run` when CI completes):
- Runs in the **base-repository** context with `checks: write`, so it has a writable token even for fork PRs.
- Downloads the `test-results-*` artifacts and publishes one inline check per platform (`Test Results (Linux)`, `Test Results (Windows)`).
- `fail-on-empty: false` so a build that fails before producing `.trx` doesn't add a spurious red report.

## #4642 checklist

- [x] Port both stop-gap fixes to `main` (superseded here by the proper fix; Azure/signing gating carried over verbatim).
- [x] Adopt the `workflow_run` pattern for test reporting (the "optional, fuller fix").
- [x] Confirm no other `ci.yml` step assumes secrets or a writable token on PRs — `Azure Login`, `Sign packages`, and `Push to MyGet` are all `main`-only; the artifact uploads work fine with a read-only fork token.

## Note on rollout

`workflow_run` only fires for the copy of `test-report.yml` on the **default branch**, so reports for fork PRs start working once this lands on `main`. Until then, PR #4634 keeps its `continue-on-error` stop-gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)