### PR TITLE
Run license validation off the construction path (fixes #4640)

### DIFF
--- a/src/AutoMapper/Configuration/MapperConfiguration.cs
+++ b/src/AutoMapper/Configuration/MapperConfiguration.cs
@@ -116,10 +116,34 @@ public sealed class MapperConfiguration : IGlobalConfiguration
         _typesInheritance = null;
         _runtimeMaps = new(GetTypeMap, openTypeMapsCount);
 
-        var validator = new LicenseValidator(loggerFactory);
-        validator.Validate(_licenseAccessor.Current);
+        // License validation is logging-only — it gates no mapping behavior and has no
+        // reader other than this call. Running it on the construction path is unsafe: under
+        // a lazily-built DI singleton the constructor holds the container's build lock, and a
+        // cold-start thread-pool starvation then deadlocks the whole app (issue #4640).
+        // Offload to a dedicated background thread and return immediately.
+        _ = Task.Factory.StartNew(
+            ValidateLicense,
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning, // dedicated thread, never the (possibly starved) pool
+            TaskScheduler.Default);          // honor LongRunning regardless of the ambient scheduler
 
         return;
+
+        void ValidateLicense()
+        {
+            try
+            {
+                var validator = new LicenseValidator(_loggerFactory);
+                validator.Validate(_licenseAccessor.Current);
+            }
+            catch (Exception ex)
+            {
+                _loggerFactory
+                    .CreateLogger("LuckyPennySoftware.AutoMapper.License")
+                    .LogError(ex, "Error validating the Lucky Penny software license key");
+            }
+        }
+
         void Seal()
         {
             foreach (var profile in Profiles)

--- a/src/AutoMapper/Licensing/LicenseAccessor.cs
+++ b/src/AutoMapper/Licensing/LicenseAccessor.cs
@@ -84,7 +84,10 @@ internal class LicenseAccessor
                 ValidateLifetime = false
             };
 
-            var validateResult = Task.Run(() => handler.ValidateTokenAsync(licenseKey, parms)).GetAwaiter().GetResult();
+            // Runs on the dedicated background thread started by MapperConfiguration (issue #4640),
+            // so there is no SynchronizationContext to deadlock on; local JWT validation completes
+            // synchronously, so this does not depend on the thread pool.
+            var validateResult = handler.ValidateTokenAsync(licenseKey, parms).GetAwaiter().GetResult();
             if (!validateResult.IsValid)
             {
                 _logger.LogCritical(validateResult.Exception, "Error validating the Lucky Penny software license key");

--- a/src/UnitTests/Licensing/LicenseValidationBackgroundTests.cs
+++ b/src/UnitTests/Licensing/LicenseValidationBackgroundTests.cs
@@ -1,0 +1,60 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace AutoMapper.UnitTests.Licensing;
+
+public class LicenseValidationBackgroundTests
+{
+    // Regression test for #4640: license validation must not run on the construction
+    // thread. Building MapperConfiguration under a lazily-built DI singleton holds the
+    // container's build lock, and validating there could deadlock the whole app under a
+    // cold-start thread-pool starvation. Validation is logging-only, so it is offloaded
+    // to a dedicated background thread. Rather than clamp the global thread pool (flaky,
+    // process-wide), we assert the property that makes the deadlock impossible: the
+    // constructor returns without validating, and validation logs on a *different* thread.
+    [Fact]
+    public void License_validation_runs_off_the_construction_thread()
+    {
+        var provider = new ThreadCapturingLoggerProvider();
+        var factory = new LoggerFactory();
+        factory.AddProvider(provider);
+
+        var constructingThreadId = Environment.CurrentManagedThreadId;
+
+        // A non-empty (junk) key forces the validation path to run; its result is logged,
+        // and that logging must happen on a background thread, never on this one.
+        _ = new MapperConfiguration(cfg => cfg.LicenseKey = "not-a-real-license-key", factory);
+
+        // The constructor returned without blocking on validation. The license log should
+        // arrive shortly, on a thread other than the one that built the configuration.
+        provider.LicenseLogged.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue();
+        provider.LoggingThreadId.ShouldNotBe(constructingThreadId);
+    }
+
+    private sealed class ThreadCapturingLoggerProvider : ILoggerProvider
+    {
+        public readonly ManualResetEventSlim LicenseLogged = new(false);
+        public int LoggingThreadId;
+
+        public ILogger CreateLogger(string categoryName) =>
+            categoryName == "LuckyPennySoftware.AutoMapper.License"
+                ? new CapturingLogger(this)
+                : NullLogger.Instance;
+
+        public void Dispose() => LicenseLogged.Dispose();
+
+        private sealed class CapturingLogger(ThreadCapturingLoggerProvider owner) : ILogger
+        {
+            public IDisposable BeginScope<TState>(TState state) => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception,
+                Func<TState, Exception, string> formatter)
+            {
+                owner.LoggingThreadId = Environment.CurrentManagedThreadId;
+                owner.LicenseLogged.Set();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #4640 — license validation can deadlock the whole app under cold-start thread-pool starvation.

## Problem

`MapperConfiguration`'s constructor validated the license key synchronously:

```csharp
var validateResult = Task.Run(() => handler.ValidateTokenAsync(licenseKey, parms))
    .GetAwaiter().GetResult();
```

Under a DI container that builds `IMapper` / `MapperConfiguration` as a **lazy singleton** (e.g. Lamar), that construction runs while the container holds its singleton-build lock. `Task.Run` queues work to the thread pool and `.GetResult()` blocks the calling thread until it completes. During a cold start that takes immediate traffic, the pool is saturated — every request thread is parked waiting on that same singleton lock — so the queued validation work can never be scheduled. The lock holder blocks forever and the whole process convoys behind it. The 16.1.1 production dump in #4640 pins it exactly: 1 lock owner, 524 waiters, CPU idle (~12%).

This is a follow-up to #4612 / #4613. The earlier `.Result` → `Task.Run(...).GetResult()` change dodged the `SynchronizationContext` deadlock but *requires a free pool thread* — the new failure mode. The synchronous `JsonWebTokenHandler.ValidateToken` is, in 8.x, itself `ValidateTokenAsync(...).ConfigureAwait(false).GetAwaiter().GetResult()` (same hazard) and is `[Obsolete]`, so it's not a fix either.

## Key insight

The validated license is **logging-only** — `LicenseValidator.Validate` just emits log messages and gates *no* mapping behavior, and the result has exactly one reader (that one call). So validation needn't be synchronous and can move off the construction path entirely.

## Fix

- **`MapperConfiguration`** — offload validation + logging to a dedicated `LongRunning` thread (`Task.Factory.StartNew` + `TaskScheduler.Default`) and return immediately. The constructor never blocks under the DI build lock, so it can't deadlock regardless of pool state. The body is wrapped in try/catch so a faulted fire-and-forget task can't surface as an unobserved exception.
- **`LicenseAccessor.ValidateKey`** — drop the `Task.Run` wrapper now that validation always runs on that dedicated background thread (no `SynchronizationContext`, and local JWT validation completes synchronously, so no pool dependency).

### Behavior change

License log lines (valid / missing / expired) now appear *shortly after* startup rather than synchronously during the first config build. A process that builds a config and exits immediately may not emit them. No functional impact — mapping never depends on the license.

## Tests

- New `LicenseValidationBackgroundTests` asserts validation logs on a **different thread** than the constructor's. Verified it **fails** on the old synchronous behavior and **passes** here.
- Full suite green: 1218 unit tests + 33 DI tests, zero failures. Clean under `TreatWarningsAsErrors`.

## Follow-up (not in this PR)

MediatR ships the same `LicenseAccessor` sync-over-async validation and almost certainly has the identical deadlock — to be ported separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)