### PR TITLE
docs: replace dead MyGet build link with CI feed link

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@
 
    If you're new to AutoMapper, please ask a question on StackOverflow first and come back here if the people there consider it a bug.
    If you've just upgraded, please read the corresponding upgrade guide first. Check https://docs.automapper.io/en/latest.
-   Try the [MyGet](https://docs.automapper.io/en/latest/The-MyGet-build.html) build.
+   Try a [CI](https://feedz.io/portal/org/lucky-penny-software/repository/automapper) build.
    Try to provide [a minimal, complete, and verifiable example](https://stackoverflow.com/help/mcve), preferably a [gist](https://gist.github.com/lbargaoanu/9c7233441c3a3413cc2b9b9ebb5964a9) that we can execute and see fail. [Here](https://gist.github.com/lbargaoanu/0cbc531306223f7ffc5468becf2642d6) is an example for ProjectTo.
    For feature requests, just clear out the below.
 -->


### PR DESCRIPTION
## Problem
`ISSUE_TEMPLATE.md` tells reporters to "Try the MyGet build" and links to `https://docs.automapper.io/en/latest/The-MyGet-build.html`.

That page is gone:

```
curl -sL -o /dev/null -w "%{http_code} %{url_effective}\n" \
  https://docs.automapper.io/en/latest/The-MyGet-build.html
# 404 https://docs.automapper.io/en/latest/The-MyGet-build.html
```

## Solution
Link to the CI feed that the project actually publishes to. `.github/workflows/ci.yml` pushes CI packages to `https://f.feedz.io/lucky-penny-software/automapper/nuget/index.json`, so the template now points at the feed portal page for that org:

```
curl -sL -o /dev/null -w "%{http_code} %{url_effective}\n" \
  https://feedz.io/portal/org/lucky-penny-software/repository/automapper
# 200
```

## Verification
Only the markdown link changes; no code or workflow changes.
