### PR TITLE
Emit the context check for the containing type map in CollectionMapper (fixes #4650)

### DIFF
--- a/src/AutoMapper/Mappers/CollectionMapper.cs
+++ b/src/AutoMapper/Mappers/CollectionMapper.cs
@@ -141,7 +141,9 @@ public sealed class CollectionMapper : IObjectMapper
             Expression CheckContext()
             {
                 var elementTypeMap = configuration.ResolveTypeMap(sourceElementType, destinationElementType);
-                return elementTypeMap == null ? null : ExpressionBuilder.CheckContext(elementTypeMap);
+                var checkElement = elementTypeMap == null ? null : ExpressionBuilder.CheckContext(elementTypeMap);
+                // OverMaxDepth uses the containing type map, so honor its context requirements too
+                return checkElement ?? (memberMap?.TypeMap is { } containingTypeMap ? ExpressionBuilder.CheckContext(containingTypeMap) : null);
             }
         }
     }

--- a/src/UnitTests/Bug/CollectionMaxDepthContext.cs
+++ b/src/UnitTests/Bug/CollectionMaxDepthContext.cs
@@ -1,0 +1,44 @@
+namespace AutoMapper.UnitTests.Bug;
+
+public class CollectionMaxDepthContext
+{
+    public class Service { public string Description { get; set; } }
+    public class ServiceDto { public string Description { get; set; } }
+
+    // Self-referential, so CheckForCycles auto-enables PreserveReferences and MaxDepth
+    public class RecursiveLine { public RecursiveLine Parent { get; set; } public List<Service> Services { get; set; } }
+    public class RecursiveLineDto { public RecursiveLineDto Parent { get; set; } public IList<ServiceDto> Services { get; set; } }
+
+    // Plain type mapping the same List<Service> -> IList<ServiceDto> pair
+    public class PlainLine { public List<Service> Services { get; set; } }
+    public class PlainLineDto { public IList<ServiceDto> Services { get; set; } }
+
+    static IMapper CreateMapper() => new MapperConfiguration(cfg =>
+    {
+        cfg.CreateMap<Service, ServiceDto>();
+        cfg.CreateMap<RecursiveLine, RecursiveLineDto>().ForMember(d => d.Services, o => o.MapAtRuntime());
+        cfg.CreateMap<PlainLine, PlainLineDto>().ForMember(d => d.Services, o => o.MapAtRuntime());
+    }).CreateMapper();
+
+    static RecursiveLine NewRecursiveLine() => new() { Services = [new Service { Description = "recursive" }] };
+    static PlainLine NewPlainLine() => new() { Services = [new Service { Description = "plain" }] };
+
+    // The collection execution plan is cached per type pair, ignoring the member map it was built
+    // for. When the recursive line compiles it first, the plan carries a max depth check for the
+    // containing type map, which needs a non default context in every other caller too.
+    [Fact]
+    public void Should_map_the_plain_line_after_the_recursive_line()
+    {
+        var mapper = CreateMapper();
+        mapper.Map<RecursiveLineDto>(NewRecursiveLine()).Services.Count.ShouldBe(1);
+        mapper.Map<PlainLineDto>(NewPlainLine()).Services.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Should_map_the_recursive_line_after_the_plain_line()
+    {
+        var mapper = CreateMapper();
+        mapper.Map<PlainLineDto>(NewPlainLine()).Services.Count.ShouldBe(1);
+        mapper.Map<RecursiveLineDto>(NewRecursiveLine()).Services.Count.ShouldBe(1);
+    }
+}


### PR DESCRIPTION
Fixes #4650.

`CollectionMapper` emits the `OverMaxDepth` check from the containing type map (`memberMap.TypeMap`) but decided whether to emit `CheckContext` from the element type map. With a containing map that has `MaxDepth > 0` and a plain element map, the generated plan calls `context.OverTypeDepth` against the default context, which throws:

```
Context.Items are only available when using a Map overload that takes Action<IMappingOperationOptions>!
```

The message is misleading — `ThrowInvalidMap` is shared between `Items` and `CheckDefault`, and the real accessor is `TypeDepth`.

Because collection execution plans are cached per type pair (`MapRequest` equality ignores `MemberMap`), the first member map to compile a given collection pair wins the cache for every other call site. Once a map with `MaxDepth` compiles the plan, unrelated callers reaching it under the default context fail, so the failure depends on warmup order rather than on configuration. This became reachable for many more configurations in 0afaf1e9, where self-referential maps started defaulting to `MaxDepth = 64`.

The fix emits the context check when either the element map or the containing type map requires it, so the guard and the depth check agree. When the containing map only sets `PreserveReferences`, the extra check is a no-op at runtime — its own plan has already replaced the default context.

Added `CollectionMaxDepthContext`, which maps the same `List<Service> -> IList<ServiceDto>` pair from a self-referential parent and a plain parent in both orders. The recursive-first case fails on `main` with the exception above and passes with this change; the plain-first case passes either way.

Full unit test suite passes (1219 tests, net10.0).

The underlying cache-key issue — member-specific state baked into a type-pair-keyed plan — is not addressed here and is worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wm2m61jXrAs4FheXR5TufH