### PR TITLE
Bump Testcontainers.MsSql to 4.14.0 to clear NU1903

### DIFF
--- a/src/IntegrationTests/AutoMapper.IntegrationTests.csproj
+++ b/src/IntegrationTests/AutoMapper.IntegrationTests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <Compile Include="..\UnitTests\AutoMapperSpecBase.cs" Link="AutoMapperSpecBase.cs" />
     <ProjectReference Include="..\AutoMapper\AutoMapper.csproj" />
-    <PackageReference Include="Testcontainers.MsSql" Version="4.8.1" />
+    <PackageReference Include="Testcontainers.MsSql" Version="4.14.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />


### PR DESCRIPTION
CI currently fails on every PR and on `main` during restore, before anything compiles:

```
src/IntegrationTests/AutoMapper.IntegrationTests.csproj : error NU1903: Warning As Error:
Package 'SSH.NET' 2024.2.0 has a known high severity vulnerability
https://github.com/advisories/GHSA-q939-rpr3-3284
```

`Testcontainers.MsSql` 4.8.1 pulls `SSH.NET` 2024.2.0 transitively. The advisory covers `SSH.NET <= 2025.1.0` and is patched in 2026.0.0, so it started breaking builds when it was published — `main` last built green on 2026-07-01, and restore failures block the whole solution.

`Testcontainers` 4.14.0 depends on `SSH.NET` 2026.0.0, so bumping `Testcontainers.MsSql` to 4.14.0 clears it. 4.13.0 and earlier still resolve to 2025.1.0 and stay vulnerable.

Verified locally: restore is clean and `AutoMapper.IntegrationTests` builds with 0 warnings and 0 errors. The integration tests themselves need Docker and were not run locally — leaving that to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wm2m61jXrAs4FheXR5TufH