### PR TITLE
Pass the source member value to Condition

### DIFF
--- a/docs/source/Conditional-mapping.md
+++ b/docs/source/Conditional-mapping.md
@@ -23,6 +23,46 @@ var configuration = new MapperConfiguration(cfg => {
 ```
 If you have a resolver, see [here](Custom-value-resolvers.html#resolvers-and-conditions) for a concrete example.
 
+## Nullable source members
+
+The source member value passed to `Condition` is the value resolved from the source object, *before* it is converted to the destination member type. This matters when the source member is a `Nullable<T>` and the destination member is a non-nullable `T`: the condition sees `null`, not `default(T)`.
+
+This makes the common PATCH scenario -- "only assign members the caller actually supplied" -- expressible with `ForAllMembers`:
+
+```c#
+class Source {
+  public int? Count { get; set; }
+}
+
+class Destination {
+  public int Count { get; set; }
+}
+
+var configuration = new MapperConfiguration(cfg => {
+  cfg.CreateMap<Source, Destination>()
+    .ForAllMembers(opt => opt.Condition((src, dest, srcMember) => srcMember != null));
+}, loggerFactory);
+
+var destination = new Destination { Count = 7 };
+mapper.Map(new Source { Count = null }, destination);
+// destination.Count is still 7 -- the null source member was skipped
+```
+
+Note that `ForAllMembers` types the source member parameter as `object`, which is what allows a `Nullable<T>` to arrive intact. A `ForMember` condition types both member parameters as the *destination* member type, so a `Nullable<T>` source cannot be represented there and the condition receives the converted value instead (`0` for `int`, `false` for `bool`). To check a nullable source member for a single member, use a `PreCondition` against the source object:
+
+```c#
+cfg.CreateMap<Source, Destination>()
+  .ForMember(dest => dest.Count, opt => opt.PreCondition(src => src.Count != null));
+```
+
+Without a condition, a null `Nullable<T>` source member is always assigned as `default(T)`. AutoMapper does not decide to map zero -- a name match always produces an assignment, and a non-nullable destination member has no way to represent the absence of a value. Roughly:
+
+```c#
+dest.Count = src.Count ?? default(int);
+```
+
+If you need a value other than `default(T)`, see [Null substitution](Null-substitution.html).
+
 ## Preconditions
 
 Similarly, there is a PreCondition method. The difference is that it runs sooner in the mapping process, before the source value is resolved (think MapFrom). So the precondition is called, then we decide which will be the source of the mapping (resolving), then the condition is called and finally the destination value is assigned.
@@ -57,6 +97,8 @@ public interface ICondition<in TSource, in TDestination, in TMember>
     bool Evaluate(TSource source, TDestination destination, TMember sourceMember, TMember destMember, ResolutionContext context);
 }
 ```
+
+As with the lambda overloads, `sourceMember` is the value resolved from the source object before conversion to the destination member type -- see [Nullable source members](#nullable-source-members).
 
 `IPreCondition<TSource, TDestination>` is evaluated before source member resolution and does not have access to member values:
 

--- a/docs/source/Conditional-mapping.md
+++ b/docs/source/Conditional-mapping.md
@@ -55,6 +55,15 @@ cfg.CreateMap<Source, Destination>()
   .ForMember(dest => dest.Count, opt => opt.PreCondition(src => src.Count != null));
 ```
 
+For this particular shape -- keep whatever the destination already holds when the source member is null -- `UseDestinationValue` does the same job without a condition at all, and works for a `ForMember` too (where a condition can't see the null):
+
+```c#
+cfg.CreateMap<Source, Destination>()
+  .ForAllMembers(opt => opt.UseDestinationValue());
+```
+
+Reach for it when the members are scalars. It is not a general PATCH switch: on a member that is itself a mapped object, `UseDestinationValue` maps *into* the existing destination instance rather than replacing it, so the nested map still overwrites that object's own members with the source's (unset ones landing as defaults). Members you want left alone entirely still need a condition.
+
 Without a condition, a null `Nullable<T>` source member is always assigned as `default(T)`. AutoMapper does not decide to map zero -- a name match always produces an assignment, and a non-nullable destination member has no way to represent the absence of a value. Roughly:
 
 ```c#

--- a/docs/source/Conditional-mapping.md
+++ b/docs/source/Conditional-mapping.md
@@ -25,7 +25,7 @@ If you have a resolver, see [here](Custom-value-resolvers.html#resolvers-and-con
 
 ## Nullable source members
 
-The source member value passed to `Condition` is the value resolved from the source object, *before* it is converted to the destination member type. This matters when the source member is a `Nullable<T>` and the destination member is a non-nullable `T`: the condition sees `null`, not `default(T)`.
+When the condition's source member parameter can hold it, `Condition` receives the value resolved from the source object *before* it is converted to the destination member type; otherwise it receives the converted value. This matters when the source member is a `Nullable<T>` and the destination member is a non-nullable `T`, because the parameter type decides whether the condition sees `null` or `default(T)`.
 
 This makes the common PATCH scenario -- "only assign members the caller actually supplied" -- expressible with `ForAllMembers`:
 
@@ -48,7 +48,7 @@ mapper.Map(new Source { Count = null }, destination);
 // destination.Count is still 7 -- the null source member was skipped
 ```
 
-Note that `ForAllMembers` types the source member parameter as `object`, which is what allows a `Nullable<T>` to arrive intact. A `ForMember` condition types both member parameters as the *destination* member type, so a `Nullable<T>` source cannot be represented there and the condition receives the converted value instead (`0` for `int`, `false` for `bool`). To check a nullable source member for a single member, use a `PreCondition` against the source object:
+`ForAllMembers` types the source member parameter as `object`, which is what allows a `Nullable<T>` to arrive intact. A `ForMember` condition types both member parameters as the *destination* member type, so a `Nullable<T>` source cannot be represented there and the condition falls back to the converted value (`0` for `int`, `false` for `bool`). To check a nullable source member for a single member, use a `PreCondition` against the source object:
 
 ```c#
 cfg.CreateMap<Source, Destination>()
@@ -98,7 +98,7 @@ public interface ICondition<in TSource, in TDestination, in TMember>
 }
 ```
 
-As with the lambda overloads, `sourceMember` is the value resolved from the source object before conversion to the destination member type -- see [Nullable source members](#nullable-source-members).
+`sourceMember` follows the same rule as the lambda overloads: the pre-conversion source value when `TMember` can hold it, the converted value otherwise -- see [Nullable source members](#nullable-source-members).
 
 `IPreCondition<TSource, TDestination>` is evaluated before source member resolution and does not have access to member values:
 

--- a/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
@@ -1,4 +1,4 @@
-namespace AutoMapper.Configuration;
+﻿namespace AutoMapper.Configuration;
 
 using static System.Linq.Expressions.Expression;
 using static AutoMapper.Execution.ExpressionBuilder;
@@ -259,8 +259,27 @@ public sealed class MemberConfigurationExpression(MemberInfo destinationMember, 
         base.ConvertUsingCore(new(valueConverter, typeof(IValueConverter<TSourceMember, TDestinationMember>), sourceMemberName));
     public void Condition(Type conditionType)
     {
-        var expr = CreateConditionExpression(conditionType);
-        ConditionCore(expr);
+        // Build the wrapper with the condition interface's OWN type arguments rather than going through
+        // CreateConditionExpression, which types the member parameters as TMember -- object on this
+        // non-generic path, erasing the condition's real member type. The plan builder reads
+        // Condition.Parameters[2].Type to decide whether the pre-conversion source value fits the
+        // condition; an erased object parameter would let a Nullable<T> reach an ICondition<,,T> and
+        // fail unboxing it. Declaring the real types keeps that decision honest, and drops the casts
+        // CreateConditionExpression needed to bridge TMember to the interface.
+        var interfaceType = conditionType.GetGenericInterface(typeof(ICondition<,,>)) ??
+            throw new InvalidOperationException($"Type '{conditionType.Name}' does not implement ICondition<TSource, TDestination, TMember>");
+        var interfaceArgs = interfaceType.GenericTypeArguments;
+        var srcParam = Parameter(interfaceArgs[0]);
+        var destParam = Parameter(interfaceArgs[1]);
+        var srcMemberParam = Parameter(interfaceArgs[2]);
+        var destMemberParam = Parameter(interfaceArgs[2]);
+        var ctxParam = Parameter(typeof(ResolutionContext));
+        var callExpression = Call(
+            Convert(ServiceLocator(conditionType), interfaceType),
+            interfaceType.GetMethod("Evaluate"),
+            srcParam, destParam, srcMemberParam, destMemberParam, ctxParam);
+        var expr = Lambda(callExpression, srcParam, destParam, srcMemberParam, destMemberParam, ctxParam);
+        PropertyMapActions.Add(pm => pm.Condition = expr);
     }
     public void PreCondition(Type preConditionType)
     {

--- a/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
+++ b/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
@@ -454,9 +454,13 @@ public ref struct TypeMapPlanBuilder(IGlobalConfiguration configuration, TypeMap
             : Assign(destinationMemberAccess, mappedMemberVariable);
         if (memberMap.Condition != null)
         {
+            var conditionMemberType = memberMap.Condition.Parameters[2].Type;
+            var conditionSourceMember = conditionMemberType.IsAssignableFrom(resolvedValueVariable.Type)
+                ? (Expression)resolvedValueVariable
+                : mappedMemberVariable;
             _expressions.Add(IfThen(
                 _configuration.ConvertReplaceParameters(memberMap.Condition,
-                    [customSource, _destination, mappedMemberVariable, destinationMemberGetter, ContextParameter]),
+                    [customSource, _destination, conditionSourceMember, destinationMemberGetter, ContextParameter]),
                 mapperExpr));
         }
         else if (!destinationMemberReadOnly)

--- a/src/UnitTests/ConditionalMapping.cs
+++ b/src/UnitTests/ConditionalMapping.cs
@@ -287,3 +287,119 @@ public class When_configuring_a_reverse_map_to_ignore_all_source_properties_with
         _source.Respect.ShouldBe("R-E-S-P-E-C-T"); // justification: if the mapping works one way, it should work in reverse
     }
 }
+public class When_using_a_condition_with_a_nullable_source_member_and_a_value_type_destination : AutoMapperSpecBase
+{
+    class Source
+    {
+        public int? Value { get; set; }
+        public bool? Toggle { get; set; }
+    }
+
+    class Destination
+    {
+        public int Value { get; set; } = 7;
+        public bool Toggle { get; set; } = true;
+    }
+
+    protected override MapperConfiguration CreateConfiguration() => new(cfg =>
+        cfg.CreateMap<Source, Destination>().ForAllMembers(o => o.Condition((source, destination, sourceMember) => sourceMember != null)));
+
+    [Fact]
+    public void Should_not_map_a_null_source_member()
+    {
+        var destination = Mapper.Map(new Source(), new Destination());
+        destination.Value.ShouldBe(7);
+        destination.Toggle.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Should_map_a_source_member_with_a_value()
+    {
+        var destination = Mapper.Map(new Source { Value = 3, Toggle = false }, new Destination());
+        destination.Value.ShouldBe(3);
+        destination.Toggle.ShouldBeFalse();
+    }
+}
+
+public class When_using_a_class_based_condition_with_a_nullable_source_member : AutoMapperSpecBase
+{
+    class Source
+    {
+        public int? Value { get; set; }
+    }
+
+    class Destination
+    {
+        public int Value { get; set; } = 7;
+    }
+
+    class SourceMemberNotNull : ICondition<Source, Destination, object>
+    {
+        public bool Evaluate(Source source, Destination destination, object sourceMember, object destMember, ResolutionContext context) =>
+            sourceMember != null;
+    }
+
+    protected override MapperConfiguration CreateConfiguration() => new(cfg =>
+        cfg.CreateMap<Source, Destination>().ForAllMembers(o => o.Condition<SourceMemberNotNull>()));
+
+    [Fact]
+    public void Should_not_map_a_null_source_member() => Mapper.Map(new Source(), new Destination()).Value.ShouldBe(7);
+
+    [Fact]
+    public void Should_map_a_source_member_with_a_value() => Mapper.Map(new Source { Value = 3 }, new Destination()).Value.ShouldBe(3);
+}
+
+public class When_using_a_condition_typed_as_the_destination_member : AutoMapperSpecBase
+{
+    class Source
+    {
+        public int? Value { get; set; }
+    }
+
+    class Destination
+    {
+        public int Value { get; set; } = 7;
+    }
+
+    protected override MapperConfiguration CreateConfiguration() => new(cfg =>
+        cfg.CreateMap<Source, Destination>().ForMember(d => d.Value, o => o.Condition((source, destination, sourceMember) => sourceMember > 0)));
+
+    [Fact]
+    public void Should_receive_the_mapped_value_because_the_source_value_does_not_fit_the_condition_member_type() =>
+        Mapper.Map(new Source(), new Destination()).Value.ShouldBe(7);
+
+    [Fact]
+    public void Should_map_a_source_member_with_a_value() => Mapper.Map(new Source { Value = 3 }, new Destination()).Value.ShouldBe(3);
+}
+
+public class When_using_a_condition_for_all_members_with_different_source_and_destination_member_types : AutoMapperSpecBase
+{
+    class Source
+    {
+        public Inner Value { get; set; }
+    }
+
+    class Destination
+    {
+        public InnerDto Value { get; set; }
+    }
+
+    class Inner
+    {
+        public int Number { get; set; }
+    }
+
+    class InnerDto
+    {
+        public int Number { get; set; }
+    }
+
+    protected override MapperConfiguration CreateConfiguration() => new(cfg =>
+    {
+        cfg.CreateMap<Inner, InnerDto>();
+        cfg.CreateMap<Source, Destination>().ForAllMembers(o => o.Condition((source, destination, sourceMember) => sourceMember is Inner));
+    });
+
+    [Fact]
+    public void Should_receive_the_source_member() => Mapper.Map<Destination>(new Source { Value = new Inner { Number = 3 } }).Value.Number.ShouldBe(3);
+}

--- a/src/UnitTests/ConditionalMapping.cs
+++ b/src/UnitTests/ConditionalMapping.cs
@@ -403,3 +403,65 @@ public class When_using_a_condition_for_all_members_with_different_source_and_de
     [Fact]
     public void Should_receive_the_source_member() => Mapper.Map<Destination>(new Source { Value = new Inner { Number = 3 } }).Value.Number.ShouldBe(3);
 }
+
+public class When_using_a_runtime_class_condition_typed_as_the_destination_member : AutoMapperSpecBase
+{
+    class Source
+    {
+        public int? Value { get; set; }
+    }
+
+    class Destination
+    {
+        public int Value { get; set; } = 7;
+    }
+
+    // Declares int, not object: the condition can't hold a null Nullable<int>, so it must receive the
+    // mapped value. The non-generic API erases TMember to object, so the wrapper has to carry the
+    // interface's own member type or this unboxes a boxed null and throws.
+    class PositiveValue : ICondition<Source, Destination, int>
+    {
+        public bool Evaluate(Source source, Destination destination, int sourceMember, int destMember, ResolutionContext context) =>
+            sourceMember > 0;
+    }
+
+    protected override MapperConfiguration CreateConfiguration() => new(cfg =>
+        cfg.CreateMap(typeof(Source), typeof(Destination))
+            .ForMember(nameof(Destination.Value), o => o.Condition(typeof(PositiveValue))));
+
+    [Fact]
+    public void Should_receive_the_mapped_value_for_a_null_source_member() =>
+        Mapper.Map<Destination>(new Source()).Value.ShouldBe(7);
+
+    [Fact]
+    public void Should_map_a_source_member_with_a_value() => Mapper.Map<Destination>(new Source { Value = 3 }).Value.ShouldBe(3);
+}
+
+public class When_using_a_runtime_class_condition_typed_as_object : AutoMapperSpecBase
+{
+    class Source
+    {
+        public int? Value { get; set; }
+    }
+
+    class Destination
+    {
+        public int Value { get; set; } = 7;
+    }
+
+    class SourceMemberNotNull : ICondition<Source, Destination, object>
+    {
+        public bool Evaluate(Source source, Destination destination, object sourceMember, object destMember, ResolutionContext context) =>
+            sourceMember != null;
+    }
+
+    protected override MapperConfiguration CreateConfiguration() => new(cfg =>
+        cfg.CreateMap(typeof(Source), typeof(Destination))
+            .ForMember(nameof(Destination.Value), o => o.Condition(typeof(SourceMemberNotNull))));
+
+    [Fact]
+    public void Should_see_the_null_source_member() => Mapper.Map<Destination>(new Source()).Value.ShouldBe(7);
+
+    [Fact]
+    public void Should_map_a_source_member_with_a_value() => Mapper.Map<Destination>(new Source { Value = 3 }).Value.ShouldBe(3);
+}


### PR DESCRIPTION
Closes #4627. Also addresses #2999, #3926 and #4530.

## The bug

`CreatePropertyMapFunc` passed `mappedMemberVariable` — the value *after* conversion to the destination member type — as the third argument to `Condition`. That argument is documented as the source member (`IMemberConfigurationExpression.Condition`: "against the source, destination, **source** and destination members"), and the fourth argument is already the destination getter.

For a `Nullable<T>` source member and a non-nullable `T` destination member, null had already collapsed to `default(T)` by the time the condition ran. `ForAllMembers` types the member parameter as `object`, so the condition boxed the `0`/`false` rather than receiving a null — which makes the "only assign what the caller supplied" PATCH scenario unexpressible. That's what's been reported repeatedly since 2018.

Confirmed on `main`, source `{ Count = null }` mapped over a destination with `Count = 7`:

| config | before | after |
|---|---|---|
| `ForAllMembers(o => o.Condition((s,d,sm) => sm != null))` | **0** | **7** |
| `ForMember(d => d.Count, o => o.PreCondition(s => s.Count != null))` | 7 | 7 |

## The fix

Use the source-typed `resolvedValueVariable` when the condition's member parameter type is assignable from it, and fall back to the mapped value otherwise:

```csharp
var conditionMemberType = memberMap.Condition.Parameters[2].Type;
var conditionSourceMember = conditionMemberType.IsAssignableFrom(resolvedValueVariable.Type)
    ? (Expression)resolvedValueVariable
    : mappedMemberVariable;
```

The fallback is load-bearing. A `ForMember` condition types both member parameters as the *destination* member type (`TMember`), so passing an `int?` there would emit `Convert(int?, int)` and throw `InvalidOperationException` on null. Those conditions keep today's behavior, and `When_using_a_condition_typed_as_the_destination_member` guards it.

## Behavior change

For `ForAllMembers` (or any condition whose member parameter is `object` or a base type) where the source and destination member types differ, the condition now receives the source member instead of the mapped destination member. `When_using_a_condition_for_all_members_with_different_source_and_destination_member_types` pins this. It matches the documented contract, but it is observable. Targeting 16.3.

No public API surface change, so no ApiCompat baseline update.

## Not changed

`dest.Int = src.NullableInt ?? default(int)` when there is no condition. A name match always produces an assignment and a non-nullable destination member cannot represent absence — that part of #2918 is inherent, and is now written down in the docs instead.

## Docs

New "Nullable source members" section in `Conditional-mapping.md` covering the `ForAllMembers` pattern, why `ForMember` conditions can't see null and should use `PreCondition`, and the `?? default(T)` rule with a pointer to null substitution. The documentation gap is arguably the bigger half of #4627 — five issues over eight years never surfaced the `PreCondition` workaround. The blanket-PATCH workaround (`cfg.Internal().ForAllPropertyMaps(...)` closing over `pm.SourceMember`) is deliberately not documented here; whether it should be promoted out of `AutoMapper.Internal` is #4656.

## Testing

Full unit suite passes (1226). The three new behavior tests fail without the `TypeMapPlanBuilder` change and pass with it. Integration tests were not run locally (they need SQL Server via Testcontainers) — leaving those to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wm2m61jXrAs4FheXR5TufH
